### PR TITLE
Use 'find_package' instead of 'find_dependency'

### DIFF
--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,8 +1,6 @@
 @PACKAGE_INIT@
 
-include(CMakeFindDependencyMacro)
-
-find_dependency(Boost CONFIG filesystem system serialization)
+find_package(Boost CONFIG REQUIRED COMPONENTS filesystem system serialization)
 
 include("${CMAKE_CURRENT_LIST_DIR}/@targets_export_name@.cmake")
 check_required_components("@PROJECT_NAME@")


### PR DESCRIPTION
'find_dependency' macro can't work with CONFIG or COMPONENTS. As a workaround
'find_package' can be used.